### PR TITLE
fix Invalid DOM property errors

### DIFF
--- a/site/components/StartScreen.js
+++ b/site/components/StartScreen.js
@@ -230,10 +230,10 @@ export default function StartScreen({ setToken, requestOtp, verifyOtp }) {
             className="opening-video"
             src="https://www.youtube.com/embed/MdnJ_neHE7Q?si=nHBkEvAzlmyh_01_"
             title="YouTube video player"
-            frameborder="0"
+            frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerpolicy="strict-origin-when-cross-origin"
-            allowfullscreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            allowFullScreen
           ></iframe>
 
           <div


### PR DESCRIPTION
was spamming
Invalid DOM property `frameborder`. Did you mean `frameBorder`? Invalid DOM property `referrerpolicy`. Did you mean `referrerPolicy`? Invalid DOM property `allowfullscreen`. Did you mean `allowFullScreen`?