### PR TITLE
fix React Hook useEffect has a missing dependency: 'fileNames'

### DIFF
--- a/site/components/useAudioManager.js
+++ b/site/components/useAudioManager.js
@@ -21,7 +21,7 @@ export default function useAudioManager(fileNames = []) {
         audioMapRef.current.set(name, audio);
       }
     });
-  }, [Array.isArray(fileNames) ? fileNames.join("|") : String(fileNames)]);
+  }, [fileNames]);
 
   const stopAll = useCallback(() => {
     audioMapRef.current.forEach((audio) => {


### PR DESCRIPTION
fixes React Hook useEffect has a missing dependency: 'fileNames'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
24:7  Warning: React Hook useEffect has a complex expression in the dependency array. Extract it to a separate  without breaking the function