### PR TITLE
Improve commas in feedback

### DIFF
--- a/site/components/MyGamesComponent.js
+++ b/site/components/MyGamesComponent.js
@@ -1911,14 +1911,6 @@ function DetailView({
                           </div>
                           <textarea
                             value={reportMessages[feedbackKey] || ""}
-                            onChange={(e) => {
-                              // Remove commas from the input
-                              const value = e.target.value.replace(/,/g, '');
-                              setReportMessages(prev => ({
-                                ...prev,
-                                [feedbackKey]: value
-                              }));
-                            }}
                             placeholder="Please explain why you're reporting this feedback..."
                             style={{
                               width: "100%",

--- a/site/components/PlaytestMode.js
+++ b/site/components/PlaytestMode.js
@@ -28,7 +28,6 @@ export default function PlaytestMode({ onExit, profile, playtestGame, playSound,
     mood: ''
   });
   const [additionalFeedback, setAdditionalFeedback] = useState('');
-  const [feedback, setFeedback] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Audio state management
@@ -686,14 +685,6 @@ export default function PlaytestMode({ onExit, profile, playtestGame, playSound,
                   </label>
                   <textarea
                     value={ratingFeedback[category]}
-                    onChange={(e) => {
-                      // Remove commas from the input
-                      const value = e.target.value.replace(/,/g, '');
-                      setRatingFeedback(prev => ({
-                        ...prev,
-                        [category]: value
-                      }));
-                    }}
                     placeholder={`How can they improve ${category}? Please be as specific as you can...`}
                     required
                     style={{
@@ -1088,11 +1079,6 @@ export default function PlaytestMode({ onExit, profile, playtestGame, playSound,
             </h3>
             <textarea
               value={additionalFeedback}
-              onChange={(e) => {
-                // Remove commas from the input
-                const value = e.target.value.replace(/,/g, '');
-                setAdditionalFeedback(value);
-              }}
               placeholder="Share any additional thoughts about the game..."
               style={{
                 width: '100%',

--- a/site/pages/api/submitPlaytest.js
+++ b/site/pages/api/submitPlaytest.js
@@ -1,5 +1,5 @@
 import Airtable from 'airtable';
-import { safeEscapeFormulaString } from './utils/security.js';
+import { safeComma, safeEscapeFormulaString } from './utils/security.js';
 
 const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(process.env.AIRTABLE_BASE_ID);
 
@@ -9,7 +9,8 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { token, playtestId, funScore, artScore, creativityScore, audioScore, moodScore, feedback, playtimeSeconds } = req.body;
+    let { token, playtestId, funScore, artScore, creativityScore, audioScore, moodScore, feedback, playtimeSeconds } = req.body;
+    feedback = safeComma(feedback);
 
     if (!token || !playtestId) {
       return res.status(400).json({ error: 'Token and playtestId are required' });

--- a/site/pages/api/updateFeedbackResponse.js
+++ b/site/pages/api/updateFeedbackResponse.js
@@ -16,7 +16,8 @@ export default async function handler(req, res) {
     return res.status(500).json({ message: 'Server configuration error' });
   }
 
-  const { token, feedbackText, response, responseMessage } = req.body || {};
+  let { token, feedbackText, response, responseMessage } = req.body || {};
+  responseMessage = safeComma(responseMessage);
   
   if (!token || !feedbackText) {
     return res.status(400).json({ message: 'Missing required fields: token, feedbackText' });

--- a/site/pages/api/utils/security.js
+++ b/site/pages/api/utils/security.js
@@ -107,3 +107,16 @@ export function sanitizeHtml(content) {
     .replace(/'/g, '&#x27;')
     .replace(/\//g, '&#x2F;');
 }
+
+
+/**
+ * Because we use Airtable rollup fields which use commas as delimiters (ew like seriously),
+ * we can't include commas in text fields included. To still allow people to include commas,
+ * we replace commas with a similar looking character, `‚` U+201A single low-9 quotation mark
+ * that Airtable won't mess with.
+ * @param {string} str 
+ * @returns 
+ */
+export function safeComma(str) {
+  return str.replace(/,/g, '‚');
+}


### PR DESCRIPTION
This moves comma handling to the server (validation was only client-side before??) and replaces commas with U+201A, a comma lookalike, instead of removing them entirely. This still is a pretty bad solution, but it's simple and avoids any Airtable issues.

Thanks!