### PR TITLE
Improve the playtest list

### DIFF
--- a/site/components/GlobalGamesComponent.js
+++ b/site/components/GlobalGamesComponent.js
@@ -190,6 +190,27 @@ export default function GlobalGamesComponent({ token, playtestMode, setPlaytestM
     </div>
   );
 
+  const completePlaytests = playtests.filter(pt => pt.status === "Complete")
+    // Sort by descending score
+    .sort((a, b) => {
+      const aScore = a.artScore + a.audioScore + a.creativityScore + a.moodScore + a.funScore;
+      const bScore = b.artScore + b.audioScore + b.creativityScore + b.moodScore + b.funScore;
+      return bScore - aScore;
+    });
+  const pendingPlaytests = playtests.filter(pt => pt.status !== "Complete")
+    .sort((a, b) => {
+      if(a.createdAt === b.createdAt) return 0;
+
+      const dateA = new Date(a.createdAt);
+      const dateB = new Date(b.createdAt);
+
+      if (isNaN(dateA) && isNaN(dateB)) return 0; // both invalid
+      if (isNaN(dateA)) return 1;
+      if (isNaN(dateB)) return -1;
+      
+      return dateB - dateA; // most recent first
+    });
+
   return (
     <div className="global-area" style={{ width: '100vw', minHeight: '100vh', position: 'relative', overflow: 'visible' }}>
       <div className="global-background"></div>
@@ -364,51 +385,107 @@ export default function GlobalGamesComponent({ token, playtestMode, setPlaytestM
                   {playtestsError}
                 </p>
               </div>
-            ) : playtests.length > 0 ? (
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 16,
-                  marginBottom: 20,
-                  width: '100%',
-                  maxWidth: 1000,
-                }}
-              >
-                {playtests.map((playtest, idx) => (
-                  <PlaytestTicket 
-                    key={playtest.id || idx} 
-                    playtest={playtest} 
-                    onPlaytestClick={(playtest) => {
-                      if (setPlaytestMode && setSelectedPlaytestGame) {
-                        setSelectedPlaytestGame({
-                          gameName: playtest.gameName,
-                          gameLink: playtest.gameLink,
-                          gameThumbnail: playtest.gameThumbnail,
-                          playtestId: playtest.playtestId,
-                          instructions: playtest.instructions,
-                          HoursSpent: playtest.HoursSpent,
-                          ownerSlackId: playtest.ownerSlackId
-                        });
-                        setPlaytestMode(true);
-                      }
-                    }}
-                  />
-                ))}
-              </div>
             ) : (
-              <div style={{ 
-                textAlign: 'center', 
-                padding: 40, 
-                maxWidth: 600,
-                background: 'rgba(255,255,255,0.1)', 
-                borderRadius: 12,
-                border: '1px solid rgba(255,255,255,0.2)'
-              }}>
-                <p style={{ color: '#fff', opacity: 0.7, fontSize: 16 }}>
-                  No playtests assigned yet. Check back later!
-                </p>
-              </div>
+              <>
+                {/* pending playtests */}
+                <div style={{ width: '100%', maxWidth: 1000, marginBottom: 32 }}>
+                  <h2 style={{ color: '#fff', marginBottom: 8, fontSize: 20 }}>Pending playtests ({pendingPlaytests.length})</h2>
+                  {pendingPlaytests.length > 0 ? (
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 16,
+                        marginBottom: 20,
+                        width: '100%',
+                      }}
+                    >
+                      {pendingPlaytests.map((playtest, idx) => (
+                        <PlaytestTicket 
+                          key={playtest.id || idx} 
+                          playtest={playtest} 
+                          onPlaytestClick={(playtest) => {
+                            if (setPlaytestMode && setSelectedPlaytestGame) {
+                              setSelectedPlaytestGame({
+                                gameName: playtest.gameName,
+                                gameLink: playtest.gameLink,
+                                gameThumbnail: playtest.gameThumbnail,
+                                playtestId: playtest.playtestId,
+                                instructions: playtest.instructions,
+                                HoursSpent: playtest.HoursSpent,
+                                ownerSlackId: playtest.ownerSlackId
+                              });
+                              setPlaytestMode(true);
+                            }
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <div style={{ 
+                      textAlign: 'center', 
+                      padding: 32, 
+                      background: 'rgba(255,255,255,0.07)', 
+                      borderRadius: 10,
+                      border: '1px solid rgba(255,255,255,0.13)',
+                      color: '#fff',
+                      opacity: 0.7,
+                      fontSize: 16
+                    }}>
+                      No pending playtests!
+                    </div>
+                  )}
+                </div>
+                {/* complete playtests */}
+                <div style={{ width: '100%', maxWidth: 1000 }}>
+                  <h2 style={{ color: '#fff', marginBottom: 8, fontSize: 20 }}>Complete playtests ({completePlaytests.length})</h2>
+                  {completePlaytests.length > 0 ? (
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 16,
+                        marginBottom: 20,
+                        width: '100%',
+                      }}
+                    >
+                      {completePlaytests.map((playtest, idx) => (
+                        <PlaytestTicket 
+                          key={playtest.id || idx} 
+                          playtest={playtest} 
+                          onPlaytestClick={(playtest) => {
+                            if (setPlaytestMode && setSelectedPlaytestGame) {
+                              setSelectedPlaytestGame({
+                                gameName: playtest.gameName,
+                                gameLink: playtest.gameLink,
+                                gameThumbnail: playtest.gameThumbnail,
+                                playtestId: playtest.playtestId,
+                                instructions: playtest.instructions,
+                                HoursSpent: playtest.HoursSpent,
+                                ownerSlackId: playtest.ownerSlackId
+                              });
+                              setPlaytestMode(true);
+                            }
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <div style={{ 
+                      textAlign: 'center', 
+                      padding: 32, 
+                      background: 'rgba(255,255,255,0.07)', 
+                      borderRadius: 10,
+                      border: '1px solid rgba(255,255,255,0.13)',
+                      color: '#fff',
+                      opacity: 0.7,
+                      fontSize: 16
+                    }}>
+                      No complete playtests yet.
+                    </div>
+                  )}
+                </div>
+              </>
             )}
           </div>
         )}

--- a/site/components/GlobalGamesComponent.js
+++ b/site/components/GlobalGamesComponent.js
@@ -208,7 +208,7 @@ export default function GlobalGamesComponent({ token, playtestMode, setPlaytestM
       if (isNaN(dateA)) return 1;
       if (isNaN(dateB)) return -1;
       
-      return dateB - dateA; // most recent first
+      return dateA - dateB; // oldest first
     });
 
   return (

--- a/site/components/PlaytestTicket.js
+++ b/site/components/PlaytestTicket.js
@@ -11,6 +11,32 @@ export default function PlaytestTicket({ playtest, onPlaytestClick }) {
     }
   };
 
+  const PLAYTEST_DAYS = 5;
+
+  // Add days remaining
+  const createdDate = new Date(playtest.createdAt);
+  if (isNaN(createdDate)) {
+    return { ...playtest, daysRemaining: 'N/A' };
+  }
+  const now = new Date();
+  const diffTime = Math.abs(now - createdDate);
+  const diffDays = diffTime / (1000 * 60 * 60 * 24);
+  const daysRemaining = Math.max(0, PLAYTEST_DAYS - diffDays);
+
+  // collapsible feedback; only on complete playtests
+  const [showFeedback, setShowFeedback] = React.useState(false);
+
+  // ref for feedback container to measure height so we can have nice size transitions
+  // I'm not sure if this is the cleanest way to do this, but most of the app is a vibe-coded mess so whatever
+  const feedbackRef = React.useRef(null);
+  const [feedbackHeight, setFeedbackHeight] = React.useState(0);
+
+  React.useEffect(() => {
+    if (playtest.status === 'Complete' && playtest.feedback && feedbackRef.current) {
+      setFeedbackHeight(feedbackRef.current.scrollHeight);
+    }
+  }, [showFeedback, playtest.status, playtest.feedback]);
+
   return (
     <div
       style={{
@@ -22,182 +48,274 @@ export default function PlaytestTicket({ playtest, onPlaytestClick }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        gap: 16,
+        flexDirection: 'column',
       }}
     >
-      {/* Left side - Spinning disk */}
-      <div style={{ position: 'relative', flexShrink: 0 }}>
-        <div
-          className="cd-vinyl"
-          style={{
-            width: 80,
-            height: 80,
-            borderRadius: '50%',
-            border: '1px solid grey',
-            background: playtest.gameThumbnail 
-              ? `url(${playtest.gameThumbnail})` 
-              : 'radial-gradient(circle at 40% 40%, #f0f0f0 0%, #d9d9d9 40%, #c7c7c7 70%, #bdbdbd 100%)',
-            backgroundSize: 'cover',
-            backgroundPosition: 'center',
-            animation: 'spin 8s linear infinite',
-            position: 'relative',
-            boxShadow: `
-              0 0 8px rgba(255, 255, 255, 0.15),
-              0 0 15px rgba(255, 255, 255, 0.1),
-              inset 0 0 5px rgba(255, 255, 255, 0.05)
-            `,
-          }}
-        >
-          {/* Vinyl overlay for rainbow effect */}
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              borderRadius: 'inherit',
-              pointerEvents: 'none',
-              opacity: 0.18,
-              background: 'conic-gradient(white, white, white, grey, grey, violet, deepskyblue, aqua, palegreen, yellow, orange, red, grey, grey, white, white, white, white, grey, grey, violet, deepskyblue, aqua, palegreen, yellow, orange, red, grey, grey, white)',
-              mixBlendMode: 'screen',
-            }}
-          />
-          
-          {/* Outer ring */}
-          <div
-            style={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              width: '30%',
-              height: '30%',
-              margin: '-15% 0 0 -15%',
-              borderRadius: 'inherit',
-              background: 'lightgrey',
-              backgroundClip: 'padding-box',
-              border: '4px solid rgba(0, 0, 0, 0.2)',
-              boxShadow: '0 0 1px grey',
-              boxSizing: 'border-box',
-            }}
-          />
-          
-          {/* Center hole */}
-          <div
-            style={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              width: '18%',
-              height: '18%',
-              margin: '-9% 0 0 -9%',
-              borderRadius: 'inherit',
-              background: '#444444',
-              backgroundClip: 'padding-box',
-              border: '4px solid rgba(0, 0, 0, 0.1)',
-              filter: 'drop-shadow(0 0 1px grey)',
-              boxSizing: 'border-box',
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Middle - Game info */}
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-        <h3 style={{ 
-          margin: 0, 
-          marginBottom: 8, 
-          fontSize: 20, 
-          fontWeight: 600,
-          color: '#000'
-        }}>
-          {playtest.gameName || 'Unnamed Game'}
-        </h3>
-        
-        <div style={{ 
+      <div
+        style={{
           display: 'flex',
+          width: '100%',
           alignItems: 'center',
-          gap: 12
-        }}>
-          <div style={{ 
-            display: 'inline-block',
-            padding: '4px 8px',
-            borderRadius: 4,
-            fontSize: 12,
-            fontWeight: 600,
-            background: playtest.status === 'Complete' ? 'rgba(40, 167, 69, 0.2)' : 
-                       playtest.status === 'In Progress' ? 'rgba(251, 191, 36, 0.2)' : 
-                       'rgba(156, 163, 175, 0.2)',
-            color: playtest.status === 'Complete' ? '#28a745' : 
-                   playtest.status === 'In Progress' ? '#fbbf24' : 
-                   '#9ca3af'
-          }}>
-            {playtest.status}
-          </div>
-          
-          {/* <span style={{ fontSize: 12, opacity: 0.7, color: '#000' }}>
-            ID: {playtest.playtestId}
-          </span> */}
-        </div>
-        
-        {playtest.instructions && (
-          <p style={{ 
-            margin: 0, 
-            marginTop: 8,
-            fontSize: 14, 
-            opacity: 0.9,
-            lineHeight: 1.4,
-            color: '#000'
-          }}>
-            {playtest.instructions}
-          </p>
-        )}
-      </div>
-
-      {/* Right side - Button or Skill Tree */}
-      <div style={{ flexShrink: 0 }}>
-        {playtest.status === 'Complete' ? (
-          <div style={{ 
-            width: 160, 
-            height: 80,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            overflow: 'visible'
-          }}>
-            <RadarChart
-              data={[
-                playtest.funScore || 0,
-                playtest.creativityScore || 0,
-                playtest.audioScore || 0,
-                playtest.artScore || 0,
-                playtest.moodScore || 0
-              ]}
-              labels={['Fun', 'Creativity', 'Audio', 'Art', 'Mood']}
-              width={160}
-              height={120}
-              backgroundColor="rgba(0, 0, 0, 0.1)"
-              borderColor="rgba(0, 0, 0, 0.8)"
-              pointBackgroundColor="rgba(0, 0, 0, 0.8)"
-              pointBorderColor="rgba(0, 0, 0, 0.8)"
-              animate={false}
-              isMiniature={true}
-            />
-          </div>
-        ) : (
-          <button
-            onClick={handlePlaytest}
+          justifyContent: 'space-between',
+          gap: 16,
+          cursor: playtest.status === 'Complete' && playtest.feedback ? 'pointer' : 'default',
+          userSelect: 'none',
+        }}
+        onClick={() => {
+          // the whole thing just toggles feedback being shown if complete
+          if (playtest.status === 'Complete' && playtest.feedback) {
+            setShowFeedback(v => !v);
+          }
+        }}
+        tabIndex={playtest.status === 'Complete' && playtest.feedback ? 0 : -1}
+        role={playtest.status === 'Complete' && playtest.feedback ? 'button' : undefined}
+        aria-expanded={showFeedback}
+      >
+        {/* Left side - Spinning disk */}
+        <div style={{ position: 'relative', flexShrink: 0 }}>
+          <div
+            className="cd-vinyl"
             style={{
-              padding: '12px 24px',
-              background: 'linear-gradient(180deg, #ff8ec3 0%, #ff6fa5 100%)',
-              color: '#fff',
-              border: 'none',
-              borderRadius: 8,
-              fontSize: 16,
-              fontWeight: 600,
-              cursor: 'pointer',
-              transition: 'all 120ms ease',
+              width: 80,
+              height: 80,
+              borderRadius: '50%',
+              border: '1px solid grey',
+              background: playtest.gameThumbnail 
+                ? `url(${playtest.gameThumbnail})` 
+                : 'radial-gradient(circle at 40% 40%, #f0f0f0 0%, #d9d9d9 40%, #c7c7c7 70%, #bdbdbd 100%)',
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              animation: 'spin 8s linear infinite',
+              position: 'relative',
+              boxShadow: `
+                0 0 8px rgba(255, 255, 255, 0.15),
+                0 0 15px rgba(255, 255, 255, 0.1),
+                inset 0 0 5px rgba(255, 255, 255, 0.05)
+              `,
             }}
           >
-            Playtest
-          </button>
+            {/* Vinyl overlay for rainbow effect */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                borderRadius: 'inherit',
+                pointerEvents: 'none',
+                opacity: 0.18,
+                background: 'conic-gradient(white, white, white, grey, grey, violet, deepskyblue, aqua, palegreen, yellow, orange, red, grey, grey, white, white, white, white, grey, grey, violet, deepskyblue, aqua, palegreen, yellow, orange, red, grey, grey, white)',
+                mixBlendMode: 'screen',
+              }}
+            />
+            
+            {/* Outer ring */}
+            <div
+              style={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                width: '30%',
+                height: '30%',
+                margin: '-15% 0 0 -15%',
+                borderRadius: 'inherit',
+                background: 'lightgrey',
+                backgroundClip: 'padding-box',
+                border: '4px solid rgba(0, 0, 0, 0.2)',
+                boxShadow: '0 0 1px grey',
+                boxSizing: 'border-box',
+              }}
+            />
+            
+            {/* Center hole */}
+            <div
+              style={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                width: '18%',
+                height: '18%',
+                margin: '-9% 0 0 -9%',
+                borderRadius: 'inherit',
+                background: '#444444',
+                backgroundClip: 'padding-box',
+                border: '4px solid rgba(0, 0, 0, 0.1)',
+                filter: 'drop-shadow(0 0 1px grey)',
+                boxSizing: 'border-box',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Middle - Game info */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <h3 style={{ 
+            margin: 0, 
+            marginBottom: 8, 
+            fontSize: 20, 
+            fontWeight: 600,
+            color: '#000'
+          }}>
+            <a href={playtest.gameLink || '#'} target="_blank" style={{ color: 'inherit' }} onClick={e => e.stopPropagation()}>
+              {playtest.gameName || 'Unnamed Game'}
+            </a>
+          </h3>
+          
+          <div style={{ 
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12
+          }}>
+            <div style={{ 
+              display: 'inline-block',
+              padding: '4px 8px',
+              borderRadius: 4,
+              fontSize: 12,
+              fontWeight: 600,
+              background: playtest.status === 'Complete' ? 'rgba(40, 167, 69, 0.2)' : 
+                         playtest.status === 'In Progress' ? 'rgba(251, 191, 36, 0.2)' : 
+                         'rgba(120, 126, 137, 0.2)',
+              color: playtest.status === 'Complete' ? '#28a745' : 
+                     playtest.status === 'In Progress' ? '#fbbf24' : 
+                     '#74787eff'
+            }}>
+              {playtest.status}
+            </div>
+
+            {/* If not complete, show the days remaining */}
+            {playtest.status !== 'Complete' && (
+              <div style={{
+                fontSize: 14,
+                color: '#a03a3aff',
+                fontWeight: 500
+              }}>
+                  {daysRemaining.toFixed(1)} days remaining
+              </div>
+            )}
+            
+            {/* <span style={{ fontSize: 12, opacity: 0.7, color: '#000' }}>
+              ID: {playtest.playtestId}
+            </span> */}
+          </div>
+          
+          {playtest.instructions && (
+            <p style={{ 
+              margin: 0, 
+              marginTop: 8,
+              fontSize: 14, 
+              opacity: 0.9,
+              lineHeight: 1.4,
+              color: '#000'
+            }}>
+              {playtest.instructions}
+            </p>
+          )}
+        </div>
+
+        {/* Right side - Button or Skill Tree */}
+        <div style={{ flexShrink: 0 }}>
+          {playtest.status === 'Complete' ? (
+            <div style={{ 
+              width: 200, 
+              height: 80,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              overflow: 'visible'
+            }}>
+              <RadarChart
+                data={[
+                  playtest.funScore || 0,
+                  playtest.creativityScore || 0,
+                  playtest.audioScore || 0,
+                  playtest.artScore || 0,
+                  playtest.moodScore || 0
+                ]}
+                labels={['Fun', 'Creativity', 'Audio', 'Art', 'Mood']}
+                width={160}
+                height={120}
+                backgroundColor="rgba(0, 0, 0, 0.1)"
+                borderColor="rgba(0, 0, 0, 0.8)"
+                pointBackgroundColor="rgba(0, 0, 0, 0.8)"
+                pointBorderColor="rgba(0, 0, 0, 0.8)"
+                animate={false}
+                isMiniature={true}
+              />
+              {/* Show feedback toggle arrow if feedback exists */}
+              {playtest.feedback && (
+                <span style={{
+                  marginLeft: 8,
+                  fontSize: 22,
+                  color: '#ff6fa5',
+                  transform: showFeedback ? 'rotate(90deg)' : 'rotate(0deg)',
+                  // the svg isn't centered lol
+                  transformOrigin: '12px 12px',
+                  transition: 'transform 0.25s',
+                  display: 'inline-block',
+                  userSelect: 'none',
+                  pointerEvents: 'none'
+                }}>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M16.75 11.989a1.82 1.82 0 0 1-.57 1.36l-6.82 6.1a1.27 1.27 0 0 1-.65.31h-.19a1.3 1.3 0 0 1-.52-.1a1.23 1.23 0 0 1-.54-.47a1.2 1.2 0 0 1-.21-.68v-13a1.2 1.2 0 0 1 .21-.69a1.23 1.23 0 0 1 1.25-.56c.24.039.464.143.65.3l6.76 6.09c.19.162.344.363.45.59c.114.234.175.49.18.75"/></svg>
+                </span>
+              )}
+            </div>
+          ) : (
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                handlePlaytest();
+              }}
+              style={{
+                padding: '12px 24px',
+                background: 'linear-gradient(180deg, #ff8ec3 0%, #ff6fa5 100%)',
+                color: '#fff',
+                border: 'none',
+                borderRadius: 8,
+                fontSize: 16,
+                fontWeight: 600,
+                cursor: 'pointer',
+                transition: 'all 120ms ease',
+              }}
+            >
+              Playtest
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          width: '100%',
+          marginTop: playtest.status === 'Complete' && playtest.feedback ? 12 : 0,
+          maxHeight: playtest.status === 'Complete' && playtest.feedback && showFeedback ? feedbackHeight+5 : 0,
+          overflow: 'hidden',
+          transition: 'max-height 0.35s cubic-bezier(0.4, 0, 0.2, 1), margin-top 0.2s',
+        }}
+        aria-hidden={!(playtest.status === 'Complete' && playtest.feedback && showFeedback)}
+      >
+        {playtest.status === 'Complete' && playtest.feedback && (
+          <div
+            ref={feedbackRef}
+            style={{
+              background: 'rgba(255,255,255,0.95)',
+              border: '1px solid #ff6fa5',
+              borderRadius: 6,
+              padding: 12,
+              color: '#222',
+              fontSize: 15,
+              whiteSpace: 'pre-wrap',
+              boxShadow: '0 2px 8px rgba(255,111,165,0.07)'
+            }}
+          >
+            <span style={{
+              fontWeight: '600'
+            }}>Playtest time:</span>
+            {` ${(playtest.playtimeSeconds / 60).toFixed(1)} minutes`}
+
+            <span style={{
+              fontWeight: '600',
+              display: 'block'
+            }}>Feedback:</span>
+            {playtest.feedback}
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
This is the same PR as before, just rebased on the detached upstream. Improves the playtest list to sort items in a nicer way, show the remaining time for available playtests, and allow users to view their feedback for old playtests.

<img width="1057" height="758" alt="image" src="https://github.com/user-attachments/assets/c2f81640-7636-48d2-b570-a97b9a0f79c2" />
