### PR TITLE
Optimize front page static data

### DIFF
--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -350,7 +350,19 @@ export async function getStaticProps() {
       throw new Error('Failed to fetch games');
     }
 
-    const games = await response.json();
+    // Idk if the API can return nullish values but I wouldn't be surprised... just in case
+    const games = (await response.json()).filter(game => !!game).map(game => ({
+      // holy inconsistent capitalization
+      id: game.id,
+      name: game.name,
+      description: game.description,
+      thumbnailUrl: game.thumbnailUrl,
+      playableURL: game.playableURL,
+      slackId: game.slackId,
+      ShibaLink: game.ShibaLink,
+      creatorDisplayName: game.creatorDisplayName,
+      creatorImage: game.creatorImage
+    }));
 
     return {
       props: {


### PR DESCRIPTION
Currently, the site sends multiple megabytes of unnecessary JSON as page props. This filters the data to not include unnecessary things like feedback, devlogs, etc.

I would actually argue that the GetAllGames endpoint should _never_ return all this data, because it's:
1. A pretty unmanageable amount of data, especially when the limit is set to its maximum of 1000; this means processing and sending way more data than is necessary most of the time
2. Not really required for anything? I don't know why other users should even be able to get the feedback, plays, average ratings, etc. of others' games--much less have it sent to them every time they open the game list
3. Pretty hard to come up with a situation where one would want this data for _every_ game returned and not specific ones, so it's probably better to put that in a separate endpoint if still needed
4. Wayyy too much to have a 100 request/minute limit. This sends like hundreds of Airtable requests for a single API request from what I can tell lol (at least users/100 + posts/100 + games/100 + plays/100 unless I'm going crazy)

I can make a more invasive change since it doesn't look like anything uses that other data from GetAllGames right now, but I wanted your opinion first.